### PR TITLE
Fixed a parse error

### DIFF
--- a/lib/kindleclippings/parser.rb
+++ b/lib/kindleclippings/parser.rb
@@ -37,7 +37,7 @@ module KindleClippings
       end
       
       first_line = lines[0].strip.scan(/^(.+) \((.+)\)$/i).first
-      second_line = lines[1].strip.scan(/^- (.+?) Loc. ([0-9-]*?) \| Added on (.+)$/i).first
+      second_line = lines[1].strip.scan(/^- (.+?) Loc. ([0-9-]*?) +\| Added on (.+)$/i).first
       
       title, author = *first_line
       type, location, date = *second_line


### PR DESCRIPTION
Fixed a failure of parsing with my "My Clipings.txt" which generated by my kindle (3rd generation). There are 2 spaces where it originally expected 1 space. It depends on kindle software version?
