### PR TITLE
Add support for Kindle Touch style highlights/notes/etc.

### DIFF
--- a/lib/kindleclippings/clipping.rb
+++ b/lib/kindleclippings/clipping.rb
@@ -4,6 +4,7 @@ module KindleClippings
     require 'date'
     
     attr_accessor :book_title, :author, :type, :location, :added_on, :content, :page
+    KINDLE_TOUCH_DATE_FORMAT = "%A, %B %d, %Y  %I:%M:%S %p"
 
     def initialize()
     end
@@ -13,7 +14,13 @@ module KindleClippings
       @author = author
       @type = type
       @location = location
-      @added_on = DateTime.strptime(added_on, "%A, %B %d, %Y, %I:%M %p")
+
+      begin
+        @added_on = DateTime.strptime(added_on, "%A, %B %d, %Y, %I:%M %p")
+      rescue ArgumentError => e
+        @added_on = DateTime.strptime(added_on, KINDLE_TOUCH_DATE_FORMAT )
+      end
+
       @content = content
       @page = page.to_i
     end

--- a/lib/kindleclippings/parser.rb
+++ b/lib/kindleclippings/parser.rb
@@ -37,7 +37,7 @@ module KindleClippings
       end
       
       first_line = lines[0].strip.scan(/^(.+) \((.+)\)$/i).first
-      second_line = lines[1].strip.scan(/^- (.+?) (?:on page (\d+) \| |)Loc. ([0-9-]*?) +\| Added on (.+)$/i).first
+      second_line = lines[1].strip.scan(/^-\s(?:Your\s)?(\w+) (?:on page (\d+) \| |)Loc(?:ation)?\.? ([0-9-]*?) +\| Added on (.+)$/i).first
       
       if first_line.nil?
         title = lines[0].strip

--- a/spec/clipping_spec.rb
+++ b/spec/clipping_spec.rb
@@ -22,4 +22,16 @@ EOF
     
     clipping.to_s.should eql(expected)
   end
+
+  it "should handle dates that include seconds" do
+    title = 'The Clean Coder: A Code of Conduct for Professional Programmers'
+    author = 'Martin, Robert C.'
+    type = :Highlight
+    location = '1637-1639'
+    added_on = 'Friday, August 10, 2012 2:10:36 AM'
+    content = 'The bottom line is that TDD works...'
+
+    clipping = KindleClippings::Clipping.new(title, author, type, location, added_on, content)
+    clipping.added_on.should == DateTime.new(2012, 8, 10, 2, 10,36)
+  end
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -6,7 +6,21 @@ describe "Parser" do
   before(:each) do
     @parser = KindleClippings::Parser.new
   end
-  
+
+  it "should parse highlights from the Kindle Touch, which have the word 'Your' before 'Highlight'" do
+    input =<<EOF
+The Clean Coder: A Code of Conduct for Professional Programmers (Martin, Robert C.)
+- Your Highlight Location 1637-1639 | Added on Friday, August 10, 2012 2:10:36 AM
+
+The bottom line is that TDD works, and everybody needs to get over it. I know this sounds strident and unilateral, but given the record I don’t think surgeons should have to defend hand-washing, and I don’t think programmers should have to defend TDD.
+EOF
+    highlight = @parser.send(:parse_clipping, input)
+    highlight.book_title.should =~ /^The Clean Coder/
+    highlight.author.should eql('Martin, Robert C.')
+    highlight.type.should eql(:Highlight)
+    highlight.location.should == '1637-1639'
+  end
+
   it "should parse clippings" do
     input =<<EOF
 Freakonomics Rev Ed (Steven D., Levitt)


### PR DESCRIPTION
Version 1.3.1 of the gem was not parsing Kindle Touch highlights correctly.  This branch includes specs and code changes to support Kindle Touch highlights.
